### PR TITLE
add package react/promise as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "class": "Horde\\Composer\\HordeInstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "^1.0|~2.0"
+        "composer-plugin-api": "^1.0|~2.0",
+        "react/promise": "~2.8"
     },
     "require-dev": {
         "composer/composer": "^1.3|~2.0"


### PR DESCRIPTION
composer aborts when calling into horde-installer-plugin code and complains that function "React\Promise\resolve()" is undefined.