### PR TITLE
Update ConfigLinker.php

### DIFF
--- a/src/ConfigLinker.php
+++ b/src/ConfigLinker.php
@@ -70,6 +70,9 @@ class ConfigLinker
                 if (file_exists($linkName)) {
                     continue;
                 }
+                if (is_link($linkName) && readlink($linkName)) {
+                    continue;
+                }
                 $this->mode == 'symlink' ? symlink($sourceName, $linkName) : copy($sourceName, $linkName);
             }
             // Do not overwrite existing files or links


### PR DESCRIPTION
file_exists does not work as expected but file does exist:

````
# php -r "var_dump(file_exists('./vendor/horde/horde/config/conf.php'));"
bool(false)
# ls -al ./vendor/horde/horde/config/conf.php
lrwxrwxrwx. 1 wwwrun www 27 Sep 29 09:06 ./vendor/horde/horde/config/conf.php -> ./var/config/horde/conf.php
````